### PR TITLE
More program options

### DIFF
--- a/include/netft_rdt_driver.h
+++ b/include/netft_rdt_driver.h
@@ -53,6 +53,8 @@ public:
   // Start receiving data from NetFT device
   NetFTRDTDriver(const std::string &address);
 
+  NetFTRDTDriver(const std::string &address, const std::string &frame_id);
+
   ~NetFTRDTDriver();
 
   //! Get newest RDT data from netFT device
@@ -73,6 +75,7 @@ protected:
 
   enum {RDT_PORT=49152};
   std::string address_;
+  std::string frame_id_;
 
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket socket_;

--- a/include/netft_rdt_driver.h
+++ b/include/netft_rdt_driver.h
@@ -53,7 +53,10 @@ public:
   // Start receiving data from NetFT device
   NetFTRDTDriver(const std::string &address);
 
-  NetFTRDTDriver(const std::string &address, const std::string &frame_id);
+  NetFTRDTDriver(const std::string &address,
+                 const std::string &frame_id,
+                 const int32_t counts_per_force,
+                 const int32_t counts_per_torque);
 
   ~NetFTRDTDriver();
 

--- a/src/netft_node.cpp
+++ b/src/netft_node.cpp
@@ -59,6 +59,7 @@ int main(int argc, char **argv)
 
   float pub_rate_hz;
   string address;
+  string frame_id;
 
   po::options_description desc("Options");
   desc.add_options()
@@ -66,10 +67,12 @@ int main(int argc, char **argv)
     ("rate", po::value<float>(&pub_rate_hz)->default_value(500.0), "set publish rate (in hertz)")
     ("wrench", "publish older Wrench message type instead of WrenchStamped")
     ("address", po::value<string>(&address), "IP address of NetFT box")
+    ("frame_id", po::value<string>(&frame_id)->default_value("base_link"), "frame_id for Wrench msgs")
     ;
      
   po::positional_options_description p;
   p.add("address",  1);
+  p.add("frame_id",  1);
 
   po::variables_map vm;
   po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
@@ -102,7 +105,7 @@ int main(int argc, char **argv)
   std::shared_ptr<netft_rdt_driver::NetFTRDTDriver> netft;
   try
   {
-    netft = std::shared_ptr<netft_rdt_driver::NetFTRDTDriver>(new netft_rdt_driver::NetFTRDTDriver(address));
+    netft = std::shared_ptr<netft_rdt_driver::NetFTRDTDriver>(new netft_rdt_driver::NetFTRDTDriver(address, frame_id));
     is_ready.data = true;
     ready_pub.publish(is_ready);
   }

--- a/src/netft_node.cpp
+++ b/src/netft_node.cpp
@@ -60,6 +60,8 @@ int main(int argc, char **argv)
   float pub_rate_hz;
   string address;
   string frame_id;
+  int32_t counts_per_force;
+  int32_t counts_per_torque;
 
   po::options_description desc("Options");
   desc.add_options()
@@ -68,6 +70,8 @@ int main(int argc, char **argv)
     ("wrench", "publish older Wrench message type instead of WrenchStamped")
     ("address", po::value<string>(&address), "IP address of NetFT box")
     ("frame_id", po::value<string>(&frame_id)->default_value("base_link"), "frame_id for Wrench msgs")
+    ("counts_per_force", po::value<int32_t>(&counts_per_force)->default_value(1000000), "Counts per force as listed by sensor webserver")
+    ("counts_per_torque", po::value<int32_t>(&counts_per_torque)->default_value(1000000), "Counts per torque as listed by sensor webserver")
     ;
      
   po::positional_options_description p;
@@ -105,7 +109,8 @@ int main(int argc, char **argv)
   std::shared_ptr<netft_rdt_driver::NetFTRDTDriver> netft;
   try
   {
-    netft = std::shared_ptr<netft_rdt_driver::NetFTRDTDriver>(new netft_rdt_driver::NetFTRDTDriver(address, frame_id));
+    netft = std::shared_ptr<netft_rdt_driver::NetFTRDTDriver>(
+      new netft_rdt_driver::NetFTRDTDriver(address, frame_id, counts_per_force, counts_per_torque));
     is_ready.data = true;
     ready_pub.publish(is_ready);
   }

--- a/src/netft_rdt_driver.cpp
+++ b/src/netft_rdt_driver.cpp
@@ -126,11 +126,17 @@ void RDTCommand::pack(uint8_t *buffer) const
 
 
 NetFTRDTDriver::NetFTRDTDriver(const std::string &address) :
-  NetFTRDTDriver(address, "base_link") // defaulting frame_id to "base_link"
+  NetFTRDTDriver(address,
+                 "base_link",  // defaulting frame_id to "base_link"
+                 1000000, // defaulting counts_per_force to 1000000
+                 1000000) // defaulting counts_per_torque to 1000000
 {
 }
 
-NetFTRDTDriver::NetFTRDTDriver(const std::string &address, const std::string &frame_id) :
+NetFTRDTDriver::NetFTRDTDriver(const std::string &address,
+                               const std::string &frame_id,
+                               const int32_t counts_per_force,
+                               const int32_t counts_per_torque) :
   address_(address),
   frame_id_(frame_id),
   socket_(io_service_),
@@ -154,10 +160,8 @@ NetFTRDTDriver::NetFTRDTDriver(const std::string &address, const std::string &fr
   // Force/Sclae is based on counts per force/torque value from device
   // these value are manually read from device webserver, but in future they 
   // may be collected using http get requests
-  static const double counts_per_force = 1000000;  
-  static const double counts_per_torque = 1000000;
-  force_scale_ = 1.0 / counts_per_force;
-  torque_scale_ = 1.0 / counts_per_torque;
+  force_scale_ = 1.0 / (double)counts_per_force;
+  torque_scale_ = 1.0 / (double)counts_per_torque;
 
   // Start receive thread  
   recv_thread_ = boost::thread(&NetFTRDTDriver::recvThreadFunc, this);

--- a/src/netft_rdt_driver.cpp
+++ b/src/netft_rdt_driver.cpp
@@ -126,7 +126,13 @@ void RDTCommand::pack(uint8_t *buffer) const
 
 
 NetFTRDTDriver::NetFTRDTDriver(const std::string &address) :
+  NetFTRDTDriver(address, "base_link") // defaulting frame_id to "base_link"
+{
+}
+
+NetFTRDTDriver::NetFTRDTDriver(const std::string &address, const std::string &frame_id) :
   address_(address),
+  frame_id_(frame_id),
   socket_(io_service_),
   stop_recv_thread_(false),
   recv_thread_running_(false),
@@ -256,7 +262,7 @@ void NetFTRDTDriver::recvThreadFunc()
         {
           tmp_data.header.seq = seq_counter_++;
           tmp_data.header.stamp = ros::Time::now();
-          tmp_data.header.frame_id = "base_link";
+          tmp_data.header.frame_id = frame_id_;
           tmp_data.wrench.force.x = double(rdt_record.fx_) * force_scale_;
           tmp_data.wrench.force.y = double(rdt_record.fy_) * force_scale_;
           tmp_data.wrench.force.z = double(rdt_record.fz_) * force_scale_;


### PR DESCRIPTION
Hi,

I've exposed the `frame_id` used in the published ROS messages and the `counts_per_force`/`counts_per_torque` values as program options. If none are provided, the previously hard-coded values are used as defaults to ensure backwards compatibility.

Other users might find this useful.

Greetings,  
Chris