### PR TITLE
Iron Updates

### DIFF
--- a/netft_utils/src/netft_hardware_interface.cpp
+++ b/netft_utils/src/netft_hardware_interface.cpp
@@ -44,6 +44,17 @@ CallbackReturn NetFTHardwareInterface::on_init(
   hw_sensor_states_.resize(
     info_.sensors[0].state_interfaces.size(), std::numeric_limits<double>::quiet_NaN());
 
+  RCLCPP_INFO_STREAM(
+  rclcpp::get_logger("NetFTHardwareInterface"), "Opening sensor at: " << ip_address_);
+
+  try {
+    ft_driver_ = std::make_unique<netft_rdt_driver::NetFTRDTDriver>(ip_address_);
+  } catch (const std::runtime_error& e) {
+    RCLCPP_ERROR_STREAM(
+      rclcpp::get_logger("NetFTHardwareInterface"), "Failed to reach sensor at: " << ip_address_);
+    throw e;
+  }
+
   return CallbackReturn::SUCCESS;
 }
 
@@ -63,17 +74,6 @@ std::vector<hardware_interface::StateInterface> NetFTHardwareInterface::export_s
 CallbackReturn NetFTHardwareInterface::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO_STREAM(
-    rclcpp::get_logger("NetFTHardwareInterface"), "Opening sensor at: " << ip_address_);
-
-  try {
-    ft_driver_ = std::make_unique<netft_rdt_driver::NetFTRDTDriver>(ip_address_);
-  } catch (const std::runtime_error& e) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("NetFTHardwareInterface"), "Failed to reach sensor at: " << ip_address_);
-    throw e;
-  }
-
   return CallbackReturn::SUCCESS;
 }
 

--- a/netft_utils/src/netft_hardware_interface.cpp
+++ b/netft_utils/src/netft_hardware_interface.cpp
@@ -86,9 +86,7 @@ CallbackReturn NetFTHardwareInterface::on_deactivate(
 hardware_interface::return_type NetFTHardwareInterface::read([[maybe_unused]] const rclcpp::Time & time, [[maybe_unused]] const rclcpp::Duration & period)
 {
   geometry_msgs::msg::WrenchStamped wrench;
-  if (ft_driver_->waitForNewData()) {
-    ft_driver_->getData(wrench);
-  }
+  ft_driver_->getData(wrench);
 
   hw_sensor_states_.at(0) = wrench.wrench.force.x;
   hw_sensor_states_.at(1) = wrench.wrench.force.y;


### PR DESCRIPTION
Makes two important fixes for use with `ros2_control`:

1. Removes the 100ms wait during the hardware interface read
2. Moves the RDT driver bringup to the `init()` function to avoid the controller manager try to read from the sensor before the `activate` function finishes setting up the sensor driver and runs into null ptr problems